### PR TITLE
Fix StatefulLayout transitions

### DIFF
--- a/android-stateful-layout-base/src/main/java/cz/kinst/jakub/view/StatefulLayout.java
+++ b/android-stateful-layout-base/src/main/java/cz/kinst/jakub/view/StatefulLayout.java
@@ -103,10 +103,12 @@ public class StatefulLayout extends FrameLayout {
 		if(mState != null && mState.equals(state))
 			return;
 
-		mState = state;
-		for(String s : mStateViews.keySet()) {
-			mStateViews.get(s).setVisibility(s.equals(state) ? View.VISIBLE : View.GONE);
+		View previousView = mStateViews.get(mState);
+		if (previousView != null) {
+			previousView.setVisibility(View.GONE);
 		}
+		mState = state;
+		mStateViews.get(state).setVisibility(View.VISIBLE);
 
 		if(mOnStateChangeListener != null)
 			mOnStateChangeListener.onStateChange(state);


### PR DESCRIPTION
Fix layout transition

Layout transitions may not happen depending the order of views, when changing visibility for
all the views. Only changing visibility for actually affected views fix this.